### PR TITLE
Wire in Conan for dependency management

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -22,18 +22,25 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install Conan
+      run: pipx install conan
+
+    - name: Detect Conan profile
+      run: conan profile detect --force
+
+    - name: Install dependencies with Conan
+      # Fetches/builds GTest and benchmark (see conanfile.txt) and generates
+      # the CMake toolchain file + 'conan-release' preset consumed below.
+      run: conan install . --build=missing -s build_type=${{env.BUILD_TYPE}}
+
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake --preset conan-release
 
     - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build --preset conan-release
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest --preset conan-release
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ https://www.bogotobogo.com/DesignPatterns/introduction.php
 
 ## Building
 
-./configure.sh
-ninja -C build
+Dependencies (GTest, benchmark) are managed with [Conan](https://conan.io/):
 
+```
+conan install . --build=missing
+cmake --preset conan-release
+cmake --build --preset conan-release
+ctest --preset conan-release
+```
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,10 @@
+[requires]
+gtest/1.17.0
+benchmark/1.9.5
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[layout]
+cmake_layout

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -3,7 +3,7 @@
 # benchmark.h's `internal` namespace to a nonexistent benchmark::internal::
 # Benchmark type when the TU also uses std::string, producing undefined
 # symbols at link time. Reproduces the same way regardless of how gtest/
-# benchmark are obtained (FetchContent, Homebrew, vcpkg) -- it's a compiler
+# benchmark are obtained (FetchContent, Homebrew, vcpkg, Conan) -- it's a compiler
 # bug, not a dependency/build-system issue. Build explicitly with
 # `cmake --build . --target perf_data_structures` once fixed/upstream'd.
 add_executable(perf_data_structures EXCLUDE_FROM_ALL perf_circular_array.cc)


### PR DESCRIPTION
## Summary
- Adds `conanfile.txt` declaring `gtest/1.17.0` and `benchmark/1.9.5`, using the `CMakeDeps`/`CMakeToolchain` generators with `cmake_layout` — the standard Conan 2 + CMake presets integration.
- No `CMakeLists.txt` changes needed: Conan's generated targets (`GTest::gtest_main`, `benchmark::benchmark`) match what the project already links against, and `CMakeUserPresets.json` was already in `.gitignore`.
- Updates CI (`.github/workflows/cmake-single-platform.yml`) to install Conan via `pipx`, detect a profile, and run `conan install` before configuring — this also fixes the CI build, which previously had no way to obtain GTest/benchmark on a bare `ubuntu-latest` runner.
- Updates the README build instructions (previously referenced a nonexistent `configure.sh`) and a stale comment in `test/perf/CMakeLists.txt` to mention Conan as a dependency source.

## Test plan
- [x] `conan install . --build=missing` succeeds locally, fetching/building gtest 1.17.0 and benchmark 1.9.5
- [x] `cmake --preset conan-release && cmake --build --preset conan-release` builds cleanly
- [x] `ctest --preset conan-release` — all 26 tests pass
- [ ] CI run on this PR (verify the new GitHub Actions steps work on `ubuntu-latest`)